### PR TITLE
Add support for TCP sockets and multiple hosts

### DIFF
--- a/haproxystats.conf
+++ b/haproxystats.conf
@@ -8,32 +8,33 @@ interval = 2
 base-dir = /var/lib/haproxystats
 
 [pull]
-loglevel        = info
-socket-dir      = /run/haproxy
-retries         = 1
-timeout         = 1
-interval        = 1
-pull-timeout    = 0.5
-pull-interval   = 10
-dst-dir         = ${paths:base-dir}/incoming
-tmp-dst-dir     = ${paths:base-dir}/incoming.tmp
-workers         = 8
+loglevel         = info
+socket-dir       = /run/haproxy
+retries          = 1
+timeout          = 1
+interval         = 1
+pull-timeout     = 0.5
+pull-interval    = 10
+dst-dir          = ${paths:base-dir}/incoming
+tmp-dst-dir      = ${paths:base-dir}/incoming.tmp
+workers          = 8
 
 [process]
-src-dir         = ${paths:base-dir}/incoming
-workers         = 4
+src-dir          = ${paths:base-dir}/incoming
+workers          = 4
 
 [graphite]
-server          = 127.0.0.1
-port            = 3002
-retries         = 2
-interval        = 0.8
-delay           = 10
-backoff         = 2
-namespace       = loadbalancers
-prefix_hostname = true
-fqdn            = true
-queue-size      = 1000000
+server           = 127.0.0.1
+port             = 3002
+retries          = 2
+interval         = 0.8
+delay            = 10
+backoff          = 2
+namespace        = loadbalancers
+prefix_namespace = true
+prefix_hostname  = true
+fqdn             = true
+queue-size       = 1000000
 
 #[local-store]
 #dir = ${paths:base-dir}/local-store

--- a/haproxystats/process.py
+++ b/haproxystats/process.py
@@ -158,8 +158,8 @@ class Consumer(multiprocessing.Process):
                 # Remove directory as data have been successfully processed.
                 log.debug('removing %s', incoming_dir)
                 try:
-                    for dirname in glob.glob(incoming_dir + '/{h}*'.format(h=self.host_id)):
-                        shutil.rmtree(dirname)
+                    for filename in glob.glob(incoming_dir + '/{h}*'.format(h=self.host_id)):
+                        os.remove(filename)
 
                     if not os.listdir(incoming_dir):
                         shutil.rmtree(incoming_dir)

--- a/haproxystats/process.py
+++ b/haproxystats/process.py
@@ -75,7 +75,8 @@ class Consumer(multiprocessing.Process):
 
         # Build graphite path (<namespace>.<hostname>.haproxy)
         graphite_tree = []
-        graphite_tree.append(self.config.get('graphite', 'namespace'))
+        if self.config.getboolean('graphite', 'prefix-namespace'):
+            graphite_tree.append(self.config.get('graphite', 'namespace'))
         if self.hostname:
             graphite_tree.append(self.hostname)
         elif self.config.getboolean('graphite', 'prefix-hostname'):
@@ -744,8 +745,8 @@ def main():
             break
 
     log.info('creating %d consumers for each host', num_consumers)
-    if config.has_section('tcp_sockets'):
-        tcp_socket_list = [s for s in config.items('tcp_sockets') if s[0] not in config.defaults()]
+    if config.has_section('tcp-sockets'):
+        tcp_socket_list = [s for s in config.items('tcp-sockets') if s[0] not in config.defaults()]
         for host, socket_list in tcp_socket_list:
             consumers = [Consumer(tasks, config, hostname=host, host_id=socket_list.split(':')[0]) for i in range(num_consumers)]
             for consumer in consumers:

--- a/haproxystats/process.py
+++ b/haproxystats/process.py
@@ -157,7 +157,7 @@ class Consumer(multiprocessing.Process):
                 # Remove directory as data have been successfully processed.
                 log.debug('removing %s', incoming_dir)
                 try:
-                    for dirname in glob.glob(incoming_dir + '/{h}*'.format(h=host_id)):
+                    for dirname in glob.glob(incoming_dir + '/{h}*'.format(h=self.host_id)):
                         shutil.rmtree(dirname)
 
                     if not os.listdir(incoming_dir):
@@ -743,9 +743,10 @@ def main():
         else:
             break
 
-    log.info('creating %d consumers', num_consumers)
+    log.info('creating %d consumers for each host', num_consumers)
     if config.has_section('tcp_sockets'):
-        for host, socket_list in config.items('tcp_sockets'):
+        tcp_socket_list = [s for s in config.items('tcp_sockets') if s[0] not in config.defaults()]
+        for host, socket_list in tcp_socket_list:
             consumers = [Consumer(tasks, config, hostname=host, host_id=socket_list.split(':')[0]) for i in range(num_consumers)]
             for consumer in consumers:
                 consumer.start()

--- a/haproxystats/process.py
+++ b/haproxystats/process.py
@@ -78,7 +78,7 @@ class Consumer(multiprocessing.Process):
         if self.config.getboolean('graphite', 'prefix-namespace'):
             graphite_tree.append(self.config.get('graphite', 'namespace'))
         if self.hostname:
-            graphite_tree.append(self.hostname)
+            graphite_tree.append(self.hostname.replace(".", "_"))
         elif self.config.getboolean('graphite', 'prefix-hostname'):
             if self.config.getboolean('graphite', 'fqdn'):
                 graphite_tree.append(socket.gethostname().replace('.', '_'))

--- a/haproxystats/pull.py
+++ b/haproxystats/pull.py
@@ -171,8 +171,8 @@ def pull_stats(config, storage_dir, loop, executor):
     results = []  # stores the result of finished tasks
     tcp_sockets = coroutines = []
     socket_dir = None
-    if config.has_section('tcp_sockets'):
-        tcp_socket_list = [s for s in config.items('tcp_sockets') if s[0] not in config.defaults()]
+    if config.has_section('tcp-sockets'):
+        tcp_socket_list = [s for s in config.items('tcp-sockets') if s[0] not in config.defaults()]
         for host, socket_list in tcp_socket_list:
             tcp_sockets = socket_list.split(',')
             log.debug('pull statistics for host %s', host)

--- a/haproxystats/pull.py
+++ b/haproxystats/pull.py
@@ -172,10 +172,11 @@ def pull_stats(config, storage_dir, loop, executor):
     tcp_sockets = coroutines = []
     socket_dir = None
     if config.has_section('tcp_sockets'):
-        for host, socket_list in config.items('tcp_sockets'):
+        tcp_socket_list = [s for s in config.items('tcp_sockets') if s[0] not in config.defaults()]
+        for host, socket_list in tcp_socket_list:
             tcp_sockets = socket_list.split(',')
             log.debug('pull statistics for host %s', host)
-            coroutines.extend([get(socket, cmd, os.path.join(storage_dir, host), loop, executor, config)
+            coroutines.extend([get(socket, cmd, storage_dir, loop, executor, config)
                     for socket in tcp_sockets
                     for cmd in CMDS])
         if not tcp_sockets:

--- a/haproxystats/pull.py
+++ b/haproxystats/pull.py
@@ -170,8 +170,8 @@ def pull_stats(config, storage_dir, loop, executor):
     # absolute directory path which contains UNIX socket files.
     results = []  # stores the result of finished tasks
     tcp_sockets = socket_dir = None
-    if config.has_section('tcp_sockets'):
-        tcp_sockets = config.get('tcp_sockets', 'endpoints').split(',')
+    if config.has_option('pull', 'tcp_sockets'):
+        tcp_sockets = config.get('pull', 'tcp_sockets').split(',')
         if not tcp_sockets:
             log.error("incorrect TCP sockets format")
             return False

--- a/haproxystats/pull.py
+++ b/haproxystats/pull.py
@@ -170,8 +170,8 @@ def pull_stats(config, storage_dir, loop, executor):
     # absolute directory path which contains UNIX socket files.
     results = []  # stores the result of finished tasks
     tcp_sockets = socket_dir = None
-    if config.has_option('pull', 'tcp_sockets'):
-        tcp_sockets = config.get('pull', 'tcp_sockets').split(',')
+    if config.has_section('tcp_sockets'):
+        tcp_sockets = config.get('tcp_sockets', 'endpoints').split(',')
         if not tcp_sockets:
             log.error("incorrect TCP sockets format")
             return False

--- a/haproxystats/utils.py
+++ b/haproxystats/utils.py
@@ -147,7 +147,7 @@ def concat_csv(csv_files):
         return None
 
 
-def get_files(path, suffix):
+def get_files(path, suffix, host_id=""):
     """
     Return the filenames from a directory which match a suffix
 
@@ -159,7 +159,7 @@ def get_files(path, suffix):
         A list of filenames
     """
     files = [filename
-             for filename in glob.glob(path + '/*{s}'.format(s=suffix))]
+             for filename in glob.glob(path + '/{h}*{s}'.format(h=host_id, s=suffix))]
 
     return files
 

--- a/haproxystats/utils.py
+++ b/haproxystats/utils.py
@@ -485,16 +485,20 @@ class EventHandler(pyinotify.ProcessEvent):
     If the event isn't for a directory no action is taken.
 
     Arguments:
-        tasks (queue obj): A queue to put items.
+        tasks_set (list of queue objects): A list of queues to put items.
     """
-    def my_init(self, tasks):  # pylint: disable=arguments-differ
-        self.tasks = tasks
+    tasks_set = []
+
+    def my_init(self, tasks_set):  # pylint: disable=arguments-differ
+        for tasks in tasks_set:
+            self.tasks_set.append(tasks)
 
     def _put_item_to_queue(self, pathname):
         """Add item to queue if and only if the pathname is a directory"""
         if os.path.isdir(pathname):
             log.info('putting %s in queue', pathname)
-            self.tasks.put(pathname)
+            for tasks in self.tasks_set:
+                tasks.put(pathname)
         else:
             log.info("ignore %s as it isn't directory", pathname)
 


### PR DESCRIPTION
Small PR adding the ability to use TCP sockets instead of UNIX ones (allows to run haproxystats on a different server, for example).

The default mode of operation is unaffected.
They can be activated simply by adding a configuration option in the pull section named 'tcp_sockets', e.g.:

```
[pull]
tcp_sockets = 10.0.0.1:1936,10.0.0.1:1937,10.0.0.1:1938
```

Right now, UNIX and TCP sockets cannot be mixed up.