### PR TITLE
Supoort grouping metrics by frontend, backend and server names

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Patrick Kaeding <patrick@kaeding.name>
 Pavlos Parissis <pavlos.parissis@booking.com>
 Pavlos Parissis <pavlos.parissis@gmail.com>
 hos7ein <hossein.a97@gmail.com>
+Christian Rovner <christian.rovner@booking.com>

--- a/haproxystats/utils.py
+++ b/haproxystats/utils.py
@@ -579,6 +579,22 @@ def configuration_check(config, section):
                                  "'servers' in the section 'pull'")
             configuration_check_for_servers(servers)
 
+    if section == 'process':
+        groups = {'frontend-groups', 'backend-groups', 'server-groups'}
+        configured_groups = groups.intersection(config.sections())
+        if config.has_option('graphite', 'group-namespace'):
+            if not config.has_option('graphite', 'group-namespace-double-writes'):
+                raise ValueError("invalid configuration, no value for option "
+                                 "'group-namespace-double-writes' in the section "
+                                 "'graphite'")
+            if not configured_groups:
+                raise ValueError("invalid configuration, at least one of these "
+                                 "sections should exist: {}".format(groups))
+        else:
+            if configured_groups:
+                raise ValueError("invalid configuration, no value for option "
+                                 "'group-namespace' in the section 'graphite'")
+
 
 def configuration_check_for_servers(servers, option='servers', section='pull'):
     """Perform a sanity check against the values for servers.

--- a/haproxystats/utils.py
+++ b/haproxystats/utils.py
@@ -583,10 +583,12 @@ def configuration_check(config, section):
         groups = {'frontend-groups', 'backend-groups', 'server-groups'}
         configured_groups = groups.intersection(config.sections())
         if config.has_option('graphite', 'group-namespace'):
-            if not config.has_option('graphite', 'group-namespace-double-writes'):
-                raise ValueError("invalid configuration, no value for option "
-                                 "'group-namespace-double-writes' in the section "
-                                 "'graphite'")
+            try:
+                config.getboolean('graphite', 'group-namespace-double-writes')
+            except (configparser.Error, ValueError) as exc:
+                raise ValueError("invalid configuration, section:'graphite' "
+                                 "option:'group-namespace-double-writes' "
+                                 "error:{e}".format(e=exc))
             if not configured_groups:
                 raise ValueError("invalid configuration, at least one of these "
                                  "sections should exist: {}".format(groups))


### PR DESCRIPTION
See the changes in README.rst for a detailed explanation of the
new functionality.

This commit introduces the following configuration options:
- [graphite] group-namespace
- [graphite] group-namespace-double-writes
- [frontend-groups] section
- [backend-groupss] section
- [server-groups] section

Additionally, the haproxystats-process daemon now accepts the
--dir command line option.