### PR TITLE
Fix runtime error when specifying a custom list of metrics

### DIFF
--- a/haproxystats/utils.py
+++ b/haproxystats/utils.py
@@ -20,7 +20,10 @@ from urllib.parse import urlparse
 import pyinotify
 import pandas
 
-from haproxystats.metrics import MetricNamesPercentage
+from haproxystats.metrics import (MetricNamesPercentage, FRONTEND_METRICS,
+                                  BACKEND_METRICS, BACKEND_AVG_METRICS,
+                                  SERVER_METRICS, SERVER_AVG_METRICS)
+
 
 log = logging.getLogger('root')  # pylint: disable=I0011,C0103
 
@@ -657,15 +660,17 @@ def check_metrics(config):
         None if all checks are successful.
 
     """
-    for metric_type in ['server', 'frontend', 'backend']:
-        option = '{t}-metrics'.format(t=metric_type)
+    valid_metrics_per_option = {
+        'frontend-metrics': FRONTEND_METRICS,
+        'backend-metrics': BACKEND_METRICS + BACKEND_AVG_METRICS,
+        'server-metrics': SERVER_METRICS + SERVER_AVG_METRICS,
+    }
+    for option, valid_metrics in valid_metrics_per_option.items():
         user_metrics = config.get('process', option, fallback=None)
         if user_metrics is not None:
             metrics = set(user_metrics.split(' '))
             if not metrics:
                 break
-            valid_metrics =\
-                globals().get('{}_METRICS'.format(metric_type.upper()))
             if not set(valid_metrics).issuperset(metrics):
                 raise ValueError("invalid configuration, section:'{s}' "
                                  "option:'{p}' error:'{e}'"


### PR DESCRIPTION
This error is triggered by specifying 'server-metrics', 'backend-metrics'
or 'frontend-metrics' in the [process] section of the config file.
The cause is an attempt to access missing variables in the global namespace.

Note this patch also fixes a secondary issue: the list of valid
metrics didn't include the AVG metrics.

Traceback (most recent call last):
  File ".../haproxystats-process", line 10, in <module>
    sys.exit(main())
  File ".../haproxystats/process.py", line 816, in main
    check_metrics(config)
  File ".../haproxystats/utils.py", line 668, in check_metrics
    if not set(valid_metrics).issuperset(metrics):
TypeError: 'NoneType' object is not iterable