### PR TITLE
Fix conditional timing metrics generation

### DIFF
--- a/haproxystats/metrics.py
+++ b/haproxystats/metrics.py
@@ -79,7 +79,8 @@ SERVER_METRICS = [
     'wretr'
 ] + COMMON
 
-SERVER_AVG_METRICS = ['ctime', 'qtime', 'rtime', 'throttle', 'ttime', 'weight']
+SERVER_AVG_METRICS = ['throttle', 'weight']
+SERVER_AVG_TIME_METRICS = ['ctime', 'qtime', 'rtime', 'ttime']
 
 BACKEND_METRICS = [
     'chkdown',
@@ -102,15 +103,8 @@ BACKEND_METRICS = [
     'wretr',
 ] + COMMON
 
-BACKEND_AVG_METRICS = [
-    'act',
-    'bck',
-    'rtime',
-    'ctime',
-    'qtime',
-    'ttime',
-    'weight'
-]
+BACKEND_AVG_METRICS = ['act', 'bck', 'weight']
+BACKEND_AVG_TIME_METRICS = ['rtime', 'ctime', 'qtime', 'ttime']
 
 FRONTEND_METRICS = [
     'comp_byp',

--- a/haproxystats/utils.py
+++ b/haproxystats/utils.py
@@ -22,7 +22,9 @@ import pandas
 
 from haproxystats.metrics import (MetricNamesPercentage, FRONTEND_METRICS,
                                   BACKEND_METRICS, BACKEND_AVG_METRICS,
-                                  SERVER_METRICS, SERVER_AVG_METRICS)
+                                  BACKEND_AVG_TIME_METRICS,
+                                  SERVER_METRICS, SERVER_AVG_METRICS,
+                                  SERVER_AVG_TIME_METRICS)
 
 
 log = logging.getLogger('root')  # pylint: disable=I0011,C0103
@@ -662,8 +664,8 @@ def check_metrics(config):
     """
     valid_metrics_per_option = {
         'frontend-metrics': FRONTEND_METRICS,
-        'backend-metrics': BACKEND_METRICS + BACKEND_AVG_METRICS,
-        'server-metrics': SERVER_METRICS + SERVER_AVG_METRICS,
+        'backend-metrics': BACKEND_METRICS + BACKEND_AVG_METRICS + BACKEND_AVG_TIME_METRICS,
+        'server-metrics': SERVER_METRICS + SERVER_AVG_METRICS + SERVER_AVG_TIME_METRICS,
     }
     for option, valid_metrics in valid_metrics_per_option.items():
         user_metrics = config.get('process', option, fallback=None)


### PR DESCRIPTION
haproxystats produces some average metrics unconditionally (eg. weight,
act) whereas others are generated conditionally (eg. ctime, ttime).
Unfortunately right now conditional generation of timing metrics has
impact on generation of unconditional average metrics. This patch splits
conditional and unconditional average metrics, so they get different
threatment. Additionally during pandas data merging process we switched from 'inner'
type (default) to 'outer' type to make sure unconditional average metrics
are always generated (otherwise they will be generated when conditional
metrics start to show up).