### PR TITLE
Do not process empty dataframes

### DIFF
--- a/haproxystats/utils.py
+++ b/haproxystats/utils.py
@@ -146,7 +146,8 @@ def concat_csv(csv_files):
         except (ValueError, OSError) as exc:
             log.error('Pandas failed to parse %s file with: %s', csv_file, exc)
         else:
-            data_frames.append(data_frame)
+            if not data_frame.empty:
+                data_frames.append(data_frame)
     if data_frames:
         return pandas.concat(data_frames)
 


### PR DESCRIPTION
Occasionally we see haproxystats-process crashing with the following
error:

haproxystats-process[59776]: 2020-08-25 08:39:55,050 [59793] [Consumer-1 ] [wrapper             ] INFO     wall clock time in seconds for process_backends 0.021
haproxystats-process[59776]: Process Consumer-2:
haproxystats-process[59776]: Traceback (most recent call last):
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/multiprocessing/process.py", line 297, in _bootstrap
haproxystats-process[59776]: self.run()
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/site-packages/haproxystats/process.py", line 212, in run
haproxystats-process[59776]: self.process_stats(incoming_dir)
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/site-packages/haproxystats/utils.py", line 835, in wrapper
haproxystats-process[59776]: result = func(self, *args, **kwargs)
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/site-packages/haproxystats/process.py", line 263, in process_stats
haproxystats-process[59776]: self.sites_stats(files)
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/site-packages/haproxystats/process.py", line 476, in sites_stats
haproxystats-process[59776]: self.process_backends(data_frame, filter_backend)
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/site-packages/haproxystats/utils.py", line 835, in wrapper
haproxystats-process[59776]: result = func(self, *args, **kwargs)
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/site-packages/haproxystats/process.py", line 574, in process_backends
haproxystats-process[59776]: aggr_avg = stats_avg.groupby(['pxname_'], as_index=False).mean()
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/site-packages/pandas/core/groupby/groupby.py", line 1306, in mean
haproxystats-process[59776]: return self._cython_agg_general('mean', **kwargs)
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/site-packages/pandas/core/groupby/groupby.py", line 3972, in _cython_agg_general
haproxystats-process[59776]: how, alt=alt, numeric_only=numeric_only, min_count=min_count)
haproxystats-process[59776]: File "/usr/python/3.7/lib/python3.7/site-packages/pandas/core/groupby/groupby.py", line 4044, in _cython_agg_blocks
haproxystats-process[59776]: raise DataError('No numeric types to aggregate')
haproxystats-process[59776]: pandas.core.base.DataError: No numeric types to aggregate

It is caused by empty data files (only headers and empty line is present). Patch makes sure we only process files which contain some data.